### PR TITLE
Support non-local IPv4 addresses

### DIFF
--- a/ios/FPStaticServer.mm
+++ b/ios/FPStaticServer.mm
@@ -1,5 +1,8 @@
 #import "FPStaticServer.h"
 #import "Server.h"
+#import <ifaddrs.h>
+#import <arpa/inet.h>
+#include <net/if.h>
 
 static NSString * const ERROR_DOMAIN = @"RNStaticServer";
 static NSString * const EVENT_NAME = @"RNStaticServer";


### PR DESCRIPTION
The proposed scope of changes enhances the existing iOS `getLocalIpAddress` function to cycle through network interfaces and return an IPv4 address of the device.