### PR TITLE
fix(android, windows): restore Android target support on Windows hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,20 @@ set(CMAKE_MACOSX_BUNDLE OFF)
 # Pre-build of PCRE2 for the target system from sources.
 
 if(CMAKE_CROSSCOMPILING AND CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
-  file(
-    COPY ${CMAKE_CURRENT_SOURCE_DIR}/windows/ReactNativeStaticServer/lighttpd/lemon.exe
-    DESTINATION ${CMAKE_BINARY_DIR}/lighttpd1.4/build
+  # Use prebuilt host-side lemon.exe; lighttpd's Ninja build expects
+  # "lighttpd1.4/build/lemon" (no extension) as a dependency and command.
+  # Provide both "lemon.exe" and "lemon" so Ninja's dependency and the
+  # actual invocation both succeed on Windows.
+  set(_LEMON_SRC
+      "${CMAKE_CURRENT_SOURCE_DIR}/windows/ReactNativeStaticServer/lighttpd/lemon.exe"
   )
-  set(LEMON_PATH ${CMAKE_BINARY_DIR}/lighttpd1.4/build/lemon.exe)
+  set(_LEMON_BUILD_DIR "${CMAKE_BINARY_DIR}/lighttpd1.4/build")
+
+  file(MAKE_DIRECTORY "${_LEMON_BUILD_DIR}")
+  file(COPY "${_LEMON_SRC}" DESTINATION "${_LEMON_BUILD_DIR}")
+  file(COPY_FILE "${_LEMON_SRC}" "${_LEMON_BUILD_DIR}/lemon")
+
+  set(LEMON_PATH "${_LEMON_BUILD_DIR}/lemon")
 endif()
 
 # Note: Archs in CMAKE_OSX_ARCHITECTURES are separated by semi-colons,


### PR DESCRIPTION
"Fixes" long‑standing issues preventing Android targets from compiling on a Windows host. Most of my testing and investigation was done through Expo, so some details reflect that workflow, but the underlying fixes apply to plain React Native as well (Tested with example app in this Repo)

overall tldr; Fixes Android builds on Windows by supplying the missing extensionless `lemon` host tool that Ninja expects, resolving lighttpd’s build failure and restoring successful RN/Expo Android compilation.

### Summary

When cross-compiling for Android on a Windows host, the lighttpd subproject can fail with errors like:

```
ninja: error: 'lighttpd1.4/build/lemon', needed by 'lighttpd1.4/build/configparser.c',
missing and no known rule to make it
```

or, after manually renaming `lemon.exe` to `lemon` it sorta works/progresses but then fails with:

```
'.../lighttpd1.4/build/lemon' is not recognized as an internal or external command
```

This seems to happen because lighttpd's generated Ninja build files:
- declare a dependency on `lighttpd1.4/build/lemon` (no extension), and
- invoke that exact path as a host tool to generate `configparser.c`.

On Windows, `react-native-static-server` we already ship a prebuilt `windows/ReactNativeStaticServer/lighttpd/lemon.exe`, and a `lemon.exe` was copied into the lighttpd build directory. However, Ninja never sees an extensionless `lemon` file it expects, and the build fails.

### What this PR changes

In `CMakeLists.txt`, for the `CMAKE_CROSSCOMPILING` + Windows host case, it now:

- uses the existing prebuilt `windows/ReactNativeStaticServer/lighttpd/lemon.exe`,
- copies it into `${CMAKE_BINARY_DIR}/lighttpd1.4/build` as `lemon.exe`,
- copies it again as `${CMAKE_BINARY_DIR}/lighttpd1.4/build/lemon` (no extension),
- sets `LEMON_PATH` to the extensionless path.

**CMake snippet:**

```cmake
if(CMAKE_CROSSCOMPILING AND CMAKE_HOST_SYSTEM_NAME MATCHES "Windows")
  # Use prebuilt host-side lemon.exe; lighttpd's Ninja build expects
  # "lighttpd1.4/build/lemon" (no extension) as a dependency and command.
  # Provide both "lemon.exe" and "lemon" so Ninja's dependency and the
  # actual invocation both succeed on Windows.
  set(_LEMON_SRC
      "${CMAKE_CURRENT_SOURCE_DIR}/windows/ReactNativeStaticServer/lighttpd/lemon.exe"
  )
  set(_LEMON_BUILD_DIR "${CMAKE_BINARY_DIR}/lighttpd1.4/build")

  file(MAKE_DIRECTORY "${_LEMON_BUILD_DIR}")
  file(COPY "${_LEMON_SRC}" DESTINATION "${_LEMON_BUILD_DIR}")
  file(COPY_FILE "${_LEMON_SRC}" "${_LEMON_BUILD_DIR}/lemon")

  set(LEMON_PATH "${_LEMON_BUILD_DIR}/lemon")
endif()
```

Not ideal as it involves copying the same file twice, but it is a tiny binary, so fairly negligible (also won't affect the final APK size).
There is probably a more elegant way to do this, but my time for this was limited and this keeps the existing "shim" approach of copying the prebuilt `lemon.exe`.

## Relation to existing issues
Two open issues which are at least partially related:

- **Addresses the lemon host-tool part of #20** (Android builds on Windows host).  \
  This addresses some of where `lemon` was mentioned. It was the first failure I hit when trying to build, and the manual workaround I found (copying `lemon.exe` to `lemon`) is now handled automatically. With the changes above, using React Native (tested with RN 0.79.6 / Expo 53), Android builds on Windows with `newArchEnabled` and I can run/build the apps successfully.

- **Related to #89** (PCRE2 detection / `pcre2-config` error on Windows→Android).  \
  This PR does not change PCRE2 detection, but fixes a separate failure mode in the Windows→Android lighttpd build. With the change, I can build successfully on Windows hosts. PCRE2 detection has presumably been fixed separately with v0.7.2, as mentioned in [#20](https://github.com/birdofpreyru/react-native-static-server/issues/20#issuecomment-1469097603) so could likely be closed at this stage.

### Testing

**Environment:**
- Windows host
- Android SDK CMake 3.22.1
- NDK 27.1.12297006

**App stack:**  \
I apologize for being a bit behind on versions; with limited time, I tested with what my existing projects were using:
- `@dr.pogodin/react-native-static-server` 0.21.0
- `@dr.pogodin/react-native-fs` 2.33.1
- React Native 0.79.6
- Expo 53

I also ran `expo run:android` with the updated setup on an M2 MacBook Pro (8GB RAM), and it built and ran successfully there as well. (iOS / macOS builds should remain unaffected overall)

Additionally, I cloned this repository (latest) and tested the included Example app. Before these changes, the Example Android app failed to build on Windows host. With this PR applied, the Example app now builds and runs to completion.

**ABIs:**
- `x86_64` (Android Simulator)
- `arm64-v8a` Physical Device, Android 15
- `armeabi-v7a` and `x86` ABIs also exist in the APK, but went untested

(ABI verification applies only to the Expo‑based builds; the example app on Windows was only checked for successful compilation, and ran on Android Simulator (x86_64).)

I'm able to build and run successfully with `expo run:android` on both tested ABIs, producing working development apps without manual intervention in `.cxx` folders, and iOS / macOS builds remain unaffected.
