### PR TITLE
Fix iOS server Promise completion

### DIFF
--- a/ios/ReactNativeStaticServer.mm
+++ b/ios/ReactNativeStaticServer.mm
@@ -122,7 +122,9 @@ RCTPromiseRejectBlock pendingReject = nil;
     SignalConsumer signalConsumer = ^void(NSString * const signal,
                                           NSString * const details)
     {
-      if (signal != LAUNCHED) self->server = nil;
+      const BOOL launched = [signal isEqualToString:LAUNCHED];
+      const BOOL crashed = [signal isEqualToString:CRASHED];
+      if (!launched) self->server = nil;
       if (pendingResolve == nil && pendingReject == nil) {
         [self emitOnServerEvent: @{
             @"serverId": serverId,
@@ -131,14 +133,19 @@ RCTPromiseRejectBlock pendingReject = nil;
           }
         ];
       } else {
-        if (signal == CRASHED) {
-          NSString *name = [NSString stringWithFormat:@"Server #%@ crashed", serverId];
-          [[RNSSException name:name details:details]
-           reject:pendingReject];
-        } else pendingResolve(details);
+        RCTPromiseResolveBlock resolve = pendingResolve;
+        RCTPromiseRejectBlock reject = pendingReject;
         pendingResolve = nil;
         pendingReject = nil;
-        dispatch_semaphore_signal(sem);
+        dispatch_async(dispatch_get_main_queue(), ^{
+          if (crashed) {
+            NSString *name = [NSString stringWithFormat:@"Server #%@ crashed", serverId];
+            [[RNSSException name:name details:details] reject:reject];
+          } else {
+            resolve(details);
+          }
+          dispatch_semaphore_signal(sem);
+        });
       }
     };
 


### PR DESCRIPTION
## What changed

- compare native server signals by string value rather than pointer identity
- deliver React Native Promise completion on the main queue
- retain the start/stop semaphore until that completion has been delivered

## Why

On React Native 0.86.2's new architecture in an iOS 26.5 simulator, lighttpd
successfully starts and listens, but the native `start()` Promise remains
pending when its resolve block is invoked directly from the lighttpd server
thread. This leaves callers waiting indefinitely even though the server is
already serving requests.

The event constants are also declared as `static` values in a header, so
pointer comparisons can differ across translation units. Value comparison
keeps `LAUNCHED` and `CRASHED` classification deterministic.

## Impact

`start()` and `stop()` now settle on React Native's main queue while preserving
the module's serialized lifecycle behavior.

## Validation

- built an Expo 57 / React Native 0.86.2 Release app for the iOS 26.5 simulator
- clean-installed and cold-launched the app
- verified the server listened on `127.0.0.1`
- verified the awaiting React Native client continued to `ready`
- loaded a WebGL map and rendered five moving point layers from the local host
